### PR TITLE
change thread timeout for win64

### DIFF
--- a/data.py
+++ b/data.py
@@ -191,7 +191,7 @@ class Data:
                                             self.tmp_chunk_tpl % cidx,
                                             begin,
                                             end)
-                                           for cidx, (begin, end) in enumerate(chunk_offsets)]).get(9999999)
+                                           for cidx, (begin, end) in enumerate(chunk_offsets)]).get(4294965)
             pool.close()
             pool.join()
         except KeyboardInterrupt:


### PR DESCRIPTION
Tread TIMEOUT_MAX is much smaller in windows than in linux
so timeout value changed for win64.
win64 max thread timeout : 4294966